### PR TITLE
Refactor HttpResponse

### DIFF
--- a/srcs/app/http/HttpResponse.cpp
+++ b/srcs/app/http/HttpResponse.cpp
@@ -7,12 +7,11 @@
 const char HttpResponse::kCRLF_[] = "\r\n";
 
 HttpResponse::HttpResponse(std::size_t status_code) {
-	const HttpStatusCodes response_codes;
-	if (!response_codes.IsValid(status_code))
+	if (!HttpStatusCodes::IsValid(status_code))
 		throw std::invalid_argument("[HttpResponse] Invalid Status");
 	http_version_ = "HTTP/1.1";
 	status_code_ = status_code;
-	reason_phrase_ = response_codes.GetReasonPhrase(status_code);
+	reason_phrase_ = HttpStatusCodes::GetReasonPhrase(status_code);
 }
 
 void	HttpResponse::SetHttpVersion(const std::string &http_version) {

--- a/srcs/app/http/HttpResponse.cpp
+++ b/srcs/app/http/HttpResponse.cpp
@@ -2,68 +2,18 @@
 #include <sstream>
 #include <stdexcept>
 #include <utility>
+#include <HttpStatusCodes.hpp>
 #include <StringUtils.hpp>
 
 const char HttpResponse::kCRLF_[] = "\r\n";
 
-const std::map<std::size_t, std::string>
-HttpResponse::kResponseStatusMap = CreateResponseStatusMap();
-
-const std::map<std::size_t, std::string>
-HttpResponse::CreateResponseStatusMap() {
-	ResponseStatusMap rs;
-
-	rs.insert(std::make_pair(100, "Continue"));
-	rs.insert(std::make_pair(101, "Switching Protocols"));
-	rs.insert(std::make_pair(200, "OK"));
-	rs.insert(std::make_pair(201, "Created"));
-	rs.insert(std::make_pair(202, "Accepted"));
-	rs.insert(std::make_pair(203, "Non-Authoritative Information"));
-	rs.insert(std::make_pair(204, "No Content"));
-	rs.insert(std::make_pair(205, "Reset Content"));
-	rs.insert(std::make_pair(206, "Partial Content"));
-	rs.insert(std::make_pair(300, "Multiple Choices"));
-	rs.insert(std::make_pair(301, "Moved Permanently"));
-	rs.insert(std::make_pair(302, "Found"));
-	rs.insert(std::make_pair(303, "See Other"));
-	rs.insert(std::make_pair(304, "Not Modified"));
-	rs.insert(std::make_pair(305, "Use Proxy"));
-	rs.insert(std::make_pair(307, "Temporary Redirect"));
-	rs.insert(std::make_pair(400, "Bad Request"));
-	rs.insert(std::make_pair(401, "Unauthorized"));
-	rs.insert(std::make_pair(402, "Payment Required"));
-	rs.insert(std::make_pair(403, "Forbidden"));
-	rs.insert(std::make_pair(404, "Not Found"));
-	rs.insert(std::make_pair(405, "Method Not Allowed"));
-	rs.insert(std::make_pair(406, "Not Acceptable"));
-	rs.insert(std::make_pair(407, "Proxy Authentication Required"));
-	rs.insert(std::make_pair(408, "Request Timeout"));
-	rs.insert(std::make_pair(409, "Conflict"));
-	rs.insert(std::make_pair(410, "Gone"));
-	rs.insert(std::make_pair(411, "Length Required"));
-	rs.insert(std::make_pair(412, "Precondition Failed"));
-	rs.insert(std::make_pair(413, "Payload Too Large"));
-	rs.insert(std::make_pair(414, "URI Too Long"));
-	rs.insert(std::make_pair(415, "Unsupported Media Type"));
-	rs.insert(std::make_pair(416, "Range Not Satisfiable"));
-	rs.insert(std::make_pair(417, "Expectation Failed"));
-	rs.insert(std::make_pair(426, "Upgrade Required"));
-	rs.insert(std::make_pair(500, "Internal Server Error"));
-	rs.insert(std::make_pair(501, "Not Implemented"));
-	rs.insert(std::make_pair(502, "Bad Gateway"));
-	rs.insert(std::make_pair(503, "Service Unavailable"));
-	rs.insert(std::make_pair(504, "Gateway Timeout"));
-	rs.insert(std::make_pair(505, "HTTP Version Not Supported"));
-	return rs;
-}
-
 HttpResponse::HttpResponse(std::size_t status_code) {
-	ResponseStatusMap::const_iterator it = kResponseStatusMap.find(status_code);
-	if (it == kResponseStatusMap.end())
+	const HttpStatusCodes response_codes;
+	if (!response_codes.IsValid(status_code))
 		throw std::invalid_argument("[HttpResponse] Invalid Status");
 	http_version_ = "HTTP/1.1";
-	status_code_ = it->first;
-	reason_phrase_ = it->second;
+	status_code_ = status_code;
+	reason_phrase_ = response_codes.GetReasonPhrase(status_code);
 }
 
 void	HttpResponse::SetHttpVersion(const std::string &http_version) {

--- a/srcs/app/http/HttpResponse.cpp
+++ b/srcs/app/http/HttpResponse.cpp
@@ -1,7 +1,6 @@
 #include <HttpResponse.hpp>
 #include <sstream>
 #include <stdexcept>
-#include <utility>
 #include <HttpStatusCodes.hpp>
 #include <StringUtils.hpp>
 

--- a/srcs/app/http/HttpStatusCodes.cpp
+++ b/srcs/app/http/HttpStatusCodes.cpp
@@ -1,0 +1,63 @@
+#include <HttpStatusCodes.hpp>
+
+const std::map<std::size_t, std::string>
+HttpStatusCodes::kStatusCodesMap_ = CreateStatusCodesMap_();
+
+const std::map<std::size_t, std::string>
+HttpStatusCodes::CreateStatusCodesMap_() {
+	StatusCodesMap_ sc;
+
+	sc.insert(std::make_pair(100, "Continue"));
+	sc.insert(std::make_pair(101, "Switching Protocols"));
+	sc.insert(std::make_pair(200, "OK"));
+	sc.insert(std::make_pair(201, "Created"));
+	sc.insert(std::make_pair(202, "Accepted"));
+	sc.insert(std::make_pair(203, "Non-Authoritative Information"));
+	sc.insert(std::make_pair(204, "No Content"));
+	sc.insert(std::make_pair(205, "Reset Content"));
+	sc.insert(std::make_pair(206, "Partial Content"));
+	sc.insert(std::make_pair(300, "Multiple Choices"));
+	sc.insert(std::make_pair(301, "Moved Permanently"));
+	sc.insert(std::make_pair(302, "Found"));
+	sc.insert(std::make_pair(303, "See Other"));
+	sc.insert(std::make_pair(304, "Not Modified"));
+	sc.insert(std::make_pair(305, "Use Proxy"));
+	sc.insert(std::make_pair(307, "Temporary Redirect"));
+	sc.insert(std::make_pair(400, "Bad Request"));
+	sc.insert(std::make_pair(401, "Unauthorized"));
+	sc.insert(std::make_pair(402, "Payment Required"));
+	sc.insert(std::make_pair(403, "Forbidden"));
+	sc.insert(std::make_pair(404, "Not Found"));
+	sc.insert(std::make_pair(405, "Method Not Allowed"));
+	sc.insert(std::make_pair(406, "Not Acceptable"));
+	sc.insert(std::make_pair(407, "Proxy Authentication Required"));
+	sc.insert(std::make_pair(408, "Request Timeout"));
+	sc.insert(std::make_pair(409, "Conflict"));
+	sc.insert(std::make_pair(410, "Gone"));
+	sc.insert(std::make_pair(411, "Length Required"));
+	sc.insert(std::make_pair(412, "Precondition Failed"));
+	sc.insert(std::make_pair(413, "Payload Too Large"));
+	sc.insert(std::make_pair(414, "URI Too Long"));
+	sc.insert(std::make_pair(415, "Unsupported Media Type"));
+	sc.insert(std::make_pair(416, "Range Not Satisfiable"));
+	sc.insert(std::make_pair(417, "Expectation Failed"));
+	sc.insert(std::make_pair(426, "Upgrade Required"));
+	sc.insert(std::make_pair(500, "Internal Server Error"));
+	sc.insert(std::make_pair(501, "Not Implemented"));
+	sc.insert(std::make_pair(502, "Bad Gateway"));
+	sc.insert(std::make_pair(503, "Service Unavailable"));
+	sc.insert(std::make_pair(504, "Gateway Timeout"));
+	sc.insert(std::make_pair(505, "HTTP Version Not Supported"));
+	return sc;
+}
+
+std::string HttpStatusCodes::GetReasonPhrase(std::size_t status_code) {
+	StatusCodesMap_::const_iterator it = kStatusCodesMap_.find(status_code);
+	if (it != kStatusCodesMap_.end())
+		return it->second;
+	return "";
+}
+
+bool		HttpStatusCodes::IsValid(std::size_t status_code) {
+	return kStatusCodesMap_.count(status_code) > 0;
+}

--- a/srcs/app/http/HttpStatusCodes.cpp
+++ b/srcs/app/http/HttpStatusCodes.cpp
@@ -4,7 +4,7 @@
 const HttpStatusCodes::StatusCodesMap_
 HttpStatusCodes::kStatusCodesMap_ = CreateStatusCodesMap_();
 
-const std::map<std::size_t, std::string>
+const HttpStatusCodes::StatusCodesMap_
 HttpStatusCodes::CreateStatusCodesMap_() {
 	StatusCodesMap_ sc;
 

--- a/srcs/app/http/HttpStatusCodes.cpp
+++ b/srcs/app/http/HttpStatusCodes.cpp
@@ -1,7 +1,7 @@
 #include <HttpStatusCodes.hpp>
 #include <utility>
 
-const std::map<std::size_t, std::string>
+const HttpStatusCodes::StatusCodesMap_
 HttpStatusCodes::kStatusCodesMap_ = CreateStatusCodesMap_();
 
 const std::map<std::size_t, std::string>

--- a/srcs/app/http/HttpStatusCodes.cpp
+++ b/srcs/app/http/HttpStatusCodes.cpp
@@ -1,4 +1,5 @@
 #include <HttpStatusCodes.hpp>
+#include <utility>
 
 const std::map<std::size_t, std::string>
 HttpStatusCodes::kStatusCodesMap_ = CreateStatusCodesMap_();

--- a/srcs/incs/HttpResponse.hpp
+++ b/srcs/incs/HttpResponse.hpp
@@ -2,6 +2,7 @@
 #define SRCS_INCS_HTTPRESPONSE_HPP_
 #include <map>
 #include <string>
+#include <HttpStatusCodes.hpp>
 
 class HttpResponse {
 	private:
@@ -26,13 +27,7 @@ class HttpResponse {
 		std::string	CreateResponseString() const;
 
 	private:
-		typedef std::size_t							StatusCode;
-		typedef std::string							ReasonPhrase;
-		typedef std::map<StatusCode, ReasonPhrase>	ResponseStatusMap;
-
-		static const ResponseStatusMap 				kResponseStatusMap;
 		static const char							kCRLF_[];
-		static const ResponseStatusMap				CreateResponseStatusMap();
 
 		std::string	http_version_;
 		std::size_t	status_code_;

--- a/srcs/incs/HttpStatusCodes.hpp
+++ b/srcs/incs/HttpStatusCodes.hpp
@@ -1,0 +1,19 @@
+#ifndef SRCS_INCS_HTTPSTATUSCODES_HPP_
+#define SRCS_INCS_HTTPSTATUSCODES_HPP_
+#include <map>
+#include <string>
+
+class HttpStatusCodes {
+	private:
+		typedef std::size_t								StatusCode_;
+		typedef std::string								ReasonPhrase_;
+		typedef std::map<StatusCode_, ReasonPhrase_>	StatusCodesMap_;
+		static const StatusCodesMap_					kStatusCodesMap_;
+		static const StatusCodesMap_					CreateStatusCodesMap_();
+
+	public:
+		static std::string	GetReasonPhrase(std::size_t status_code);
+		static bool			IsValid(std::size_t status_code);
+};
+
+#endif  // SRCS_INCS_HTTPSTATUSCODES_HPP_

--- a/srcs/incs/HttpStatusCodes.hpp
+++ b/srcs/incs/HttpStatusCodes.hpp
@@ -5,9 +5,8 @@
 
 class HttpStatusCodes {
 	private:
-		typedef std::size_t								StatusCode_;
-		typedef std::string								ReasonPhrase_;
-		typedef std::map<StatusCode_, ReasonPhrase_>	StatusCodesMap_;
+		// Map of HTTP response status codes and reason phrases
+		typedef std::map<std::size_t, std::string>		StatusCodesMap_;
 		static const StatusCodesMap_					kStatusCodesMap_;
 		static const StatusCodesMap_					CreateStatusCodesMap_();
 

--- a/srcs/incs/HttpStatusCodes.hpp
+++ b/srcs/incs/HttpStatusCodes.hpp
@@ -4,15 +4,19 @@
 #include <string>
 
 class HttpStatusCodes {
+	public:
+		static std::string	GetReasonPhrase(std::size_t status_code);
+		static bool			IsValid(std::size_t status_code);
+
 	private:
 		// Map of HTTP response status codes and reason phrases
 		typedef std::map<std::size_t, std::string>		StatusCodesMap_;
 		static const StatusCodesMap_					kStatusCodesMap_;
 		static const StatusCodesMap_					CreateStatusCodesMap_();
 
-	public:
-		static std::string	GetReasonPhrase(std::size_t status_code);
-		static bool			IsValid(std::size_t status_code);
+		// Disable copy construct and assign
+		HttpStatusCodes(const HttpStatusCodes &);
+		HttpStatusCodes&	operator=(const HttpStatusCodes &);
 };
 
 #endif  // SRCS_INCS_HTTPSTATUSCODES_HPP_


### PR DESCRIPTION
Extracted the HTTP status codes map from HttpResponse to a new class HttpStatusCodes

This way we can reuse this part in HttpRequestHandler