### PR TITLE
Fix make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,16 @@ include $(SRC_DIR)/target/generaterules.mk
 
 .PHONY: test
 test:
+	make
 	make -C srcs/app/test
 	$(BLD_DIR)/utest_app
 
 .PHONY: lint
 lint:
 	$(LINT) $(LINTFLAGS) .
+
+ngxsyntax:
+	cd $(SRC_DIR)/app/test/config_analyser/nginx_docker && docker-compose up
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
"make test" is now building the test sources before it builds the project's sources. This means that by the time it builds the project's sources, it has already overwritten the "CXXFLAGS" variable, which means that when we do a make test we're building the sources as C++11. This is a regression, and this PR attempts to fix this.