### PR TITLE
Task/improve connection io status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ NOTES.md
 ### draft and personal files
 *.nocommit
 nocommit/*
+
+### ides
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "optional": "cpp",
-        "variant": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "optional": "cpp",
+        "variant": "cpp"
+    }
+}

--- a/srcs/app/server/Connection.cpp
+++ b/srcs/app/server/Connection.cpp
@@ -3,24 +3,24 @@
 #include <HttpRequestHandler.hpp>
 
 Connection::Connection(const ServerConfig &server_config, int socket)
-	: server_config_(server_config), socket_(socket),
-		ready_for_response_(false), keep_alive_(true) {
+	: server_config_(server_config), socket_(socket), keep_alive_(true) {
 }
 
-bool	Connection::ReadRequest() {
+enum ReadRequestStatus::Type	Connection::ReadRequest() {
 	char	buffer[4096];
 
 	int nbytes = recv(socket_, buffer, sizeof(buffer), 0);
-	if (nbytes <= 0)
-		return false;
-	ready_for_response_ = true;
+	if (nbytes <= 0) {
+		return ReadRequestStatus::kFail;
+	}
+	ReadRequestStatus::Type status = raw_request_.empty() ?
+									ReadRequestStatus::kStart :
+									ReadRequestStatus::kSuccess;
 	raw_request_.append(&buffer[0], &buffer[nbytes]);
-	return true;
+	return status;
 }
 
-bool	Connection::SendResponse() {
-	if (!ready_for_response_)
-		return true;
+enum SendResponseStatus::Type	Connection::SendResponse() {
 	if (raw_response_.empty()) {
 		IRequestHandler *handler =
 			new HttpRequestHandler(server_config_, raw_request_);
@@ -30,13 +30,16 @@ bool	Connection::SendResponse() {
 		delete handler;
 	}
 	int nbytes = send(socket_, raw_response_.c_str(), raw_response_.size(), 0);
-	if (nbytes <= 0)
-		return false;
+	if (nbytes <= 0) {
+		return SendResponseStatus::kFail;
+	}
 	raw_response_.erase(0, nbytes);
 	if (raw_response_.empty()) {
-		ready_for_response_ = false;
-		if (!keep_alive_)
-			return false;
+		if (keep_alive_) {
+			return SendResponseStatus::kCompleteKeep;
+		} else {
+			return SendResponseStatus::kCompleteClose;
+		}
 	}
-	return true;
+	return SendResponseStatus::kSuccess;
 }

--- a/srcs/app/server/Server.cpp
+++ b/srcs/app/server/Server.cpp
@@ -60,18 +60,18 @@ bool	Server::HasConnection(int sd) {
 	return connections_.count(sd) > 0;
 }
 
-bool	Server::ReadRequest(int sd) {
+enum ReadRequestStatus::Type	Server::ReadRequest(int sd) {
 	std::map<int, Connection>::iterator it = connections_.find(sd);
 	if (it == connections_.end()) {
-		return false;
+		return ReadRequestStatus::kFail;
 	}
 	return it->second.ReadRequest();
 }
 
-bool	Server::SendResponse(int sd) {
+enum SendResponseStatus::Type	Server::SendResponse(int sd) {
 	std::map<int, Connection>::iterator it = connections_.find(sd);
 	if (it == connections_.end()) {
-		return false;
+		return SendResponseStatus::kFail;
 	}
 	return it->second.SendResponse();
 }

--- a/srcs/app/server/WebServer.cpp
+++ b/srcs/app/server/WebServer.cpp
@@ -6,7 +6,8 @@
 
 WebServer::WebServer() {
 	FD_ZERO(&master_set_);
-	FD_ZERO(&read_set_);
+	FD_ZERO(&tmp_read_set_);
+	FD_ZERO(&tmp_write_set_);
 	FD_ZERO(&write_set_);
 	max_sd_ = -1;
 }
@@ -19,26 +20,27 @@ void	WebServer::Init(const std::string &pathname) {
 void	WebServer::Run() {
 	AddListeningSocketsToMasterSet_();
 	while (max_sd_ != -1) {
-		std::memcpy(&read_set_, &master_set_, sizeof(master_set_));
-		std::memcpy(&write_set_, &master_set_, sizeof(master_set_));
+		std::memcpy(&tmp_read_set_, &master_set_, sizeof(master_set_));
+		std::memcpy(&tmp_write_set_, &write_set_, sizeof(master_set_));
 		int ready_connections =
-			select(max_sd_ + 1, &read_set_, &write_set_, NULL, NULL);
+			select(max_sd_ + 1, &tmp_read_set_, &tmp_write_set_, NULL, NULL);
 		if (ready_connections < 0) {
 			throw std::runtime_error(std::strerror(errno));
 		} else if (ready_connections == 0) {
 			throw std::runtime_error("select returned 0 with NULL timeout");
 		}
 		for (int sd = 0; sd <= max_sd_ && ready_connections > 0; ++sd) {
-			if (FD_ISSET(sd, &read_set_)) {
+			if (FD_ISSET(sd, &tmp_read_set_)) {
 				--ready_connections;
 				if (IsListeningSocket_(sd)) {
 					AcceptNewConnection_(sd);
 				} else {
 					ReadRequest_(sd);
 				}
-			} else if (FD_ISSET(sd, &write_set_) && !IsListeningSocket_(sd)) {
+			} else if (FD_ISSET(sd, &tmp_write_set_)) {
 				--ready_connections;
 				SendResponse_(sd);
+                FD_CLR(sd, &write_set_);
 			}
 		}
 	}
@@ -127,8 +129,11 @@ void	WebServer::ReadRequest_(int sd) {
 	if (!server_ptr->ReadRequest(sd)) {
 		server_ptr->RemoveConnection(sd);
 		FD_CLR(sd, &master_set_);
+		FD_CLR(sd, &write_set_);
 		SetMaxSocket_(sd);
+        return ;
 	}
+    FD_SET(sd, &write_set_);
 }
 
 void	WebServer::SendResponse_(int sd) {
@@ -138,6 +143,7 @@ void	WebServer::SendResponse_(int sd) {
 	if (!server_ptr->SendResponse(sd)) {
 		server_ptr->RemoveConnection(sd);
 		FD_CLR(sd, &master_set_);
+		FD_CLR(sd, &write_set_);
 		SetMaxSocket_(sd);
 	}
 }

--- a/srcs/app/server/WebServer.cpp
+++ b/srcs/app/server/WebServer.cpp
@@ -6,9 +6,7 @@
 #include <ServerConfig.hpp>
 
 WebServer::WebServer() {
-	FD_ZERO(&master_set_);
-	FD_ZERO(&read_set_);
-	FD_ZERO(&tmp_write_set_);
+	FD_ZERO(&all_set_);
 	FD_ZERO(&write_set_);
 	max_sd_ = -1;
 }
@@ -21,17 +19,17 @@ void	WebServer::Init(const std::string &pathname) {
 void	WebServer::Run() {
 	AddListeningSocketsToMasterSet_();
 	while (max_sd_ != -1) {
-		std::memcpy(&read_set_, &master_set_, sizeof(master_set_));
-		std::memcpy(&tmp_write_set_, &write_set_, sizeof(master_set_));
+		std::memcpy(&tmp_read_set_, &all_set_, sizeof(all_set_));
+		std::memcpy(&tmp_write_set_, &write_set_, sizeof(all_set_));
 		int ready_connections =
-			select(max_sd_ + 1, &read_set_, &tmp_write_set_, NULL, NULL);
+			select(max_sd_ + 1, &tmp_read_set_, &tmp_write_set_, NULL, NULL);
 		if (ready_connections < 0) {
 			throw std::runtime_error(std::strerror(errno));
 		} else if (ready_connections == 0) {
 			throw std::runtime_error("select returned 0 with NULL timeout");
 		}
 		for (int sd = 0; sd <= max_sd_ && ready_connections > 0; ++sd) {
-			if (FD_ISSET(sd, &read_set_)) {
+			if (FD_ISSET(sd, &tmp_read_set_)) {
 				--ready_connections;
 				if (IsListeningSocket_(sd)) {
 					AcceptNewConnection_(sd);
@@ -66,7 +64,7 @@ void	WebServer::AddListeningSocketsToMasterSet_() {
 
 	for (; server_it != servers_.end(); ++server_it) {
 		int listen_sd = server_it->second.GetListeningSocket();
-		FD_SET(listen_sd, &master_set_);
+		FD_SET(listen_sd, &all_set_);
 		if (max_sd_ < listen_sd) {
 			max_sd_ = listen_sd;
 		}
@@ -74,11 +72,11 @@ void	WebServer::AddListeningSocketsToMasterSet_() {
 }
 
 void	WebServer::SetMaxSocket_(int curr_sd) {
-    if (curr_sd == max_sd_) {
-        while (FD_ISSET(max_sd_, &master_set_) == 0) {
-            --max_sd_;
-        }
-    }
+	if (curr_sd == max_sd_) {
+		while (FD_ISSET(max_sd_, &all_set_) == 0) {
+			--max_sd_;
+		}
+	}
 }
 
 std::map<int, Server>::iterator
@@ -88,7 +86,7 @@ WebServer::FindListeningServer_(int sd) {
 
 // Accept the new connection
 // Add it to the server connections
-// And to the master_set_
+// And to the all_set_
 void	WebServer::AcceptNewConnection_(int sd) {
 	ServersMap_::iterator	server_it = FindListeningServer_(sd);
 	Server *server_ptr = &server_it->second;
@@ -100,7 +98,7 @@ void	WebServer::AcceptNewConnection_(int sd) {
 	if (fcntl(new_sd, F_SETFL, O_NONBLOCK) < 0) {
 		throw std::runtime_error(std::strerror(errno));
 	}
-	FD_SET(new_sd, &master_set_);
+	FD_SET(new_sd, &all_set_);
 	server_ptr->AddConnection(new_sd);
 	if (max_sd_ < new_sd) {
 		max_sd_ = new_sd;
@@ -131,7 +129,7 @@ void	WebServer::ReadRequest_(int sd) {
 		FD_SET(sd, &write_set_);
 	} else if (status == ReadRequestStatus::kFail) {
 		server_ptr->RemoveConnection(sd);
-		FD_CLR(sd, &master_set_);
+		FD_CLR(sd, &all_set_);
 		FD_CLR(sd, &write_set_);
 		SetMaxSocket_(sd);
 	}
@@ -147,7 +145,7 @@ void	WebServer::SendResponse_(int sd) {
 	} else if (status == SendResponseStatus::kFail ||
 				status == SendResponseStatus::kCompleteClose) {
 		server_ptr->RemoveConnection(sd);
-		FD_CLR(sd, &master_set_);
+		FD_CLR(sd, &all_set_);
 		FD_CLR(sd, &write_set_);
 		SetMaxSocket_(sd);
 	}

--- a/srcs/incs/Connection.hpp
+++ b/srcs/incs/Connection.hpp
@@ -3,6 +3,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <string>
+#include <ConnectionIOStatus.hpp>
 #include <HttpRequest.hpp>
 #include <HttpResponse.hpp>
 #include <ServerConfig.hpp>
@@ -10,13 +11,12 @@
 class Connection {
 	public:
 		Connection(const ServerConfig &server_config, int sd);
-		bool	ReadRequest();
-		bool	SendResponse();
+		enum ReadRequestStatus::Type	ReadRequest();
+		enum SendResponseStatus::Type	SendResponse();
 
 	private:
 		const ServerConfig	&server_config_;
 		const int			socket_;
-		bool				ready_for_response_;
 		bool				keep_alive_;
 		std::string			raw_request_;
 		std::string			raw_response_;

--- a/srcs/incs/ConnectionIOStatus.hpp
+++ b/srcs/incs/ConnectionIOStatus.hpp
@@ -1,0 +1,21 @@
+#ifndef SRCS_INCS_CONNECTIONIOSTATUS_HPP_
+#define SRCS_INCS_CONNECTIONIOSTATUS_HPP_
+
+struct ReadRequestStatus {
+	enum Type {
+		kFail,
+		kSuccess,
+		kStart
+	};
+};
+
+struct SendResponseStatus {
+	enum Type {
+		kFail,
+		kSuccess,
+		kCompleteClose,
+		kCompleteKeep
+	};
+};
+
+#endif  // SRCS_INCS_CONNECTIONIOSTATUS_HPP_

--- a/srcs/incs/Server.hpp
+++ b/srcs/incs/Server.hpp
@@ -21,8 +21,9 @@ class Server {
 		void	RemoveConnection(int sd);
 		int		GetListeningSocket() const;
 		bool	HasConnection(int sd);
-		bool	ReadRequest(int sd);
-		bool	SendResponse(int sd);
+
+		enum ReadRequestStatus::Type	ReadRequest(int sd);
+		enum SendResponseStatus::Type	SendResponse(int sd);
 };
 
 #endif  // SRCS_INCS_SERVER_HPP_

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -17,10 +17,10 @@ class WebServer {
 
 		Config		config_;
 		ServersMap_	servers_;
-		fd_set		master_set_;
-		fd_set		read_set_;
-		fd_set		tmp_write_set_;
+		fd_set		all_set_;
 		fd_set		write_set_;
+		fd_set		tmp_read_set_;
+		fd_set		tmp_write_set_;
 		int			max_sd_;
 
 	public:

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -18,7 +18,8 @@ class WebServer {
 		Config		config_;
 		ServersMap_	servers_;
 		fd_set		master_set_;
-		fd_set		read_set_;
+		fd_set		tmp_read_set_;
+		fd_set		tmp_write_set_;
 		fd_set		write_set_;
 		int			max_sd_;
 

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -18,7 +18,7 @@ class WebServer {
 		Config		config_;
 		ServersMap_	servers_;
 		fd_set		master_set_;
-		fd_set		tmp_read_set_;
+		fd_set		read_set_;
 		fd_set		tmp_write_set_;
 		fd_set		write_set_;
 		int			max_sd_;


### PR DESCRIPTION
Currently `Connection::ReadRequest()` and `Connection::SendResponse()` return a boolean which can signal fail or success.

And the `WebServer` requires more information to manage the `write_set_` of `select()`.

This PR fixes sending responses that require multiple calls to send().

resolve #56 