### PR TITLE
[HttpRequest] Fix ParseBody_ segfault

### DIFF
--- a/srcs/app/http/HttpRequest.cpp
+++ b/srcs/app/http/HttpRequest.cpp
@@ -296,8 +296,8 @@ bool	HttpRequest::ParseBody_(const std::string &raw_request) {
 		return true;
 	errno = 0;
 	char *endptr;
-	std::size_t content_length = std::strtoul(
-			GetHeaderValue("Content-Length").c_str(), &endptr, 10);
+	std::string content_length_str = GetHeaderValue("Content-Length");
+	std::size_t content_length = std::strtoul(content_length_str.c_str(), &endptr, 10);
 	return !errno && *endptr == '\0' && content_length == body_.size();
 }
 

--- a/srcs/app/http/HttpRequest.cpp
+++ b/srcs/app/http/HttpRequest.cpp
@@ -297,7 +297,8 @@ bool	HttpRequest::ParseBody_(const std::string &raw_request) {
 	errno = 0;
 	char *endptr;
 	std::string content_length_str = GetHeaderValue("Content-Length");
-	std::size_t content_length = std::strtoul(content_length_str.c_str(), &endptr, 10);
+	std::size_t content_length =
+						std::strtoul(content_length_str.c_str(), &endptr, 10);
 	return !errno && *endptr == '\0' && content_length == body_.size();
 }
 


### PR DESCRIPTION
Assign the content length to a string to prevent accessing the memory of a temporary variable from the destructor.

This part was segfaulting when compiling with the `-fsanitize=address` flag.