### PR TITLE
Task/form data file

### DIFF
--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -1,0 +1,231 @@
+#include <FormFile.hpp>
+#include <stdexcept>
+#include <StringUtils.hpp>
+
+const char FormFile::kCRLF[] = "\r\n";
+const char FormFile::kWhitespace[] = " \t";
+
+FormFile::FormFile(const HttpRequest &request) {
+	ParseRequestContentType_(request);
+	ParseRequestBody_(request);
+}
+
+std::string	FormFile::GetFilename() const {
+	return filename_;
+}
+
+std::string	FormFile::GetFileContent() const {
+	return file_content_;
+}
+
+// Syntax: Content-Type: multipart/form-data; boundary=something
+void	FormFile::ParseRequestContentType_(const HttpRequest &request) {
+	if (!request.HasHeader("Content-Type")) {
+		throw std::invalid_argument("[FormFile] Invalid request Content-Type");
+	}
+	// Check the media-type, should be multipart/form-data
+	const std::string content_type = request.GetHeaderValue("Content-Type");
+	std::size_t start = 0;
+	std::size_t end = content_type.find(';');
+	const std::string media_type = content_type.substr(start, end - start);
+	if (TrimString(media_type, kWhitespace) != "multipart/form-data") {
+		throw std::invalid_argument("[FormFile] Invalid media-type");
+	}
+
+	// Check the boundary field
+	if (end == std::string::npos ||
+			content_type.find(';', end + 1) != std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid boundary");
+	}
+	start = end + 1;
+	const std::string directive =
+							TrimString(content_type.substr(start), kWhitespace);
+	const std::string name = "boundary=";
+	if (!directive.rfind(name, 0) == 0) {
+		throw std::invalid_argument("[FormFile] Invalid boundary");
+	}
+	boundary_ = directive.substr(name.length());
+	if (boundary_.empty() || boundary_.size() > 70) {
+		throw std::invalid_argument("[FormFile] Invalid boundary");
+	}
+}
+
+/*
+** https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1
+POST /foo HTTP/1.1
+Content-Length: 68137
+Content-Type: multipart/form-data; boundary=something
+
+--something
+Content-Disposition: form-data; name="myFile"; filename="foo.txt"
+Content-Type: text/plain
+
+(content of the uploaded file foo.txt)
+--something--
+*/
+
+/*
+** Example body
+--something\r\nContent-Disposition: form-data; name="filename"; filename="foo.txt"\r\nContent-Type: text/plain\r\n\r\nfoobar\n\r\n--something--\r\n
+*/
+void	FormFile::ParseRequestBody_(const HttpRequest &request) {
+	const std::string dash_boundary = "--";
+	const std::string body = request.GetBody();
+
+	// Skip first boundary
+	const std::string form_part_start = dash_boundary + boundary_ + kCRLF;
+	if (body.rfind(form_part_start, 0) != 0) {
+		throw std::invalid_argument("[FormFile] Invalid body boundary");
+	}
+
+	// Parse the headers to extract the filename
+	std::size_t	headers_start = form_part_start.size();
+	std::size_t headers_end = body.find(
+									std::string(kCRLF) + kCRLF, headers_start);
+	if (headers_end == std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid body headers");
+	}
+	headers_end += (sizeof(kCRLF) - 1) * 2;
+	std::string headers =
+						body.substr(headers_start, headers_end - headers_start);
+	ParseFormHeaders_(headers);
+
+	// Parse the file content
+	std::size_t file_start = headers_end;
+	std::string form_part_end =
+					kCRLF + dash_boundary + boundary_ + dash_boundary + kCRLF;
+	std::size_t file_end = body.find(form_part_end, file_start);
+	file_content_ = body.substr(file_start, file_end - file_start);
+}
+
+/*
+** Example of the form headers
+Content-Disposition: form-data; name="myFile"; filename="foo.txt"\r\nContent-Type: text/plain\r\n\r\n
+*/
+void	FormFile::ParseFormHeaders_(const std::string &headers) {
+	// Parse the content disposition
+	std::size_t start = 0;
+	std::size_t end = headers.find(kCRLF);
+	if (end == std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
+	}
+	const std::string content_disposition = headers.substr(start, end);
+	ParseFormContentDisposition_(content_disposition);
+
+	// Parse the Content-Type of the form data
+	start = end + sizeof(kCRLF) - 1;
+	end = headers.find(std::string(kCRLF) + kCRLF, start);
+	if (end == std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid form Content-Type");
+	}
+	const std::string content_type = headers.substr(start, end - start);
+	ParseFormContentType_(content_type);
+
+	// Check that there are no more headers
+	end += (sizeof(kCRLF) - 1) * 2;
+	if (end != headers.size()) {
+		throw std::invalid_argument("[FormFile] Invalid form headers");
+	}
+}
+
+// Syntax: Content-Disposition: form-data; name="myFile"; filename="foo.txt"
+void	FormFile::ParseFormContentDisposition_(const std::string &header) {
+	// Parse header name
+	std::size_t start = 0;
+	std::size_t end = header.find(':');
+	const std::string header_name = header.substr(start, end - start);
+	const std::string lwc_header_name =
+							ToLowerString(TrimString(header_name, kWhitespace));
+	if (lwc_header_name != "content-disposition" || end == std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid form header");
+	}
+
+	// Parse the disposition type
+	start = end + 1;
+	end = header.find(';', start);
+	if (end == std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
+	}
+	const std::string disposition_type = header.substr(start, end - start);
+	if (TrimString(disposition_type, kWhitespace) != "form-data") {
+		throw std::invalid_argument(
+				"[FormFile] Invalid Content-Disposition type");
+	}
+
+	// Parse the disposition name
+	std::size_t index = end + 1;
+	index = SkipSpace(header, index);
+	std::string name = "name=";
+	if (header.rfind(name, index) != index) {
+		throw std::invalid_argument(
+				"[FormFile] Invalid Content-Disposition name");
+	}
+	index += name.size();
+	ParseDoubleQuotedString(header, &index);
+	index = SkipSpace(header, index);
+	if (index >= header.size() || header[index] != ';') {
+		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
+	}
+	index += 1;
+	index = SkipSpace(header, index);
+
+	// Parse the disposition filename
+	name = "filename=";
+	if (header.rfind(name, index) != index) {
+		throw std::invalid_argument(
+				"[FormFile] Invalid Content-Disposition filename");
+	}
+	index += name.size();
+	const std::string quoted_filename = ParseDoubleQuotedString(header, &index);
+	filename_ = TrimString(quoted_filename, "\"");
+	if (index != header.size()) {
+		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
+	}
+}
+
+// Syntax: Content-Type: text/plain
+void	FormFile::ParseFormContentType_(const std::string &header) const {
+	// Parse header name
+	std::size_t start = 0;
+	std::size_t end = header.find(':');
+	const std::string header_name = header.substr(start, end - start);
+	const std::string lwc_header_name =
+							ToLowerString(TrimString(header_name, kWhitespace));
+	if (lwc_header_name != "content-type" || end == std::string::npos) {
+		throw std::invalid_argument("[FormFile] Invalid form header");
+	}
+}
+
+std::size_t	FormFile::SkipSpace(const std::string &str, std::size_t idx) const {
+	return str.find_first_not_of(kWhitespace, idx);
+}
+
+std::string
+FormFile::ParseDoubleQuotedString(const std::string &str,
+									std::size_t *index) const {
+	const char double_quote = '"';
+	const char backslash = '\\';
+	if (str[*index] != double_quote || str.size() < 3) {
+		throw std::invalid_argument("[FormFile] Invalid value");
+	}
+	std::size_t start = *index;
+	*index += 1;
+	bool found = false;
+	while (!found) {
+		if (str[*index] == backslash) {
+			if (*index + 2 >= str.size()) {
+				throw std::invalid_argument("[FormFile] Missing closing quote");
+			}
+			*index += 2;
+		} else if (str[*index] == double_quote) {
+			found = true;
+		} else if (*index < str.size()) {
+			++(*index);
+		} else {
+			throw std::invalid_argument("[FormFile] Missing closing quote");
+		}
+	}
+	++(*index);
+	const std::string unquoted_str = str.substr(start, *index - start);
+	return unquoted_str;
+}

--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -119,7 +119,7 @@ void	FormFile::ParseFormHeaders_(const std::string &headers) {
 		throw std::invalid_argument("[FormFile] Invalid form Content-Type");
 	}
 	const std::string content_type = headers.substr(start, end - start);
-	ParseFormContentType_(content_type);
+	ParseHeaderName_(content_type, 0, "content-type");
 
 	// Verify that there are no more headers
 	end += (sizeof(kCRLF) - 1) * 2;
@@ -173,11 +173,6 @@ void	FormFile::ParseFormContentDisposition_(const std::string &header) {
 	if (index != header.size()) {
 		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
 	}
-}
-
-// Syntax: Content-Type: image/gif
-void	FormFile::ParseFormContentType_(const std::string &header) const {
-	ParseHeaderName_(header, 0, "content-type");
 }
 
 std::string

--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -24,12 +24,12 @@ void	FormFile::ParseRequestContentType_(const HttpRequest &request) {
 		throw std::invalid_argument("[FormFile] Invalid request Content-Type");
 	}
 	const std::string content_type = request.GetHeaderValue("Content-Type");
-	std::size_t end = ParseMediaType_(content_type, 0, "multipart/form-data");
+	std::size_t index = ParseMediaType_(content_type, 0, "multipart/form-data");
+	ParseBoundary_(content_type, index);
+}
 
-	// Parse the boundary field
-	std::size_t start = end;
-	const std::string directive =
-							TrimString(content_type.substr(start), kWhitespace);
+void	FormFile::ParseBoundary_(const std::string &str, std::size_t index) {
+	const std::string directive = TrimString(str.substr(index), kWhitespace);
 	const std::string name = "boundary=";
 	if (directive.rfind(name, 0) != 0) {
 		throw std::invalid_argument("[FormFile] Invalid boundary");
@@ -181,7 +181,6 @@ FormFile::ParseDoubleQuotedString_(const std::string &str,
 std::size_t
 FormFile::ParseHeaderName_(const std::string &str, std::size_t start,
 							const std::string &name) const {
-	// Parse header name
 	std::size_t end = str.find(':', start);
 	if (end == std::string::npos) {
 		throw std::invalid_argument("[FormFile] Invalid header format");

--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -204,7 +204,6 @@ std::string
 FormFile::ParseDoubleQuotedString(const std::string &str,
 									std::size_t *index) const {
 	const char double_quote = '"';
-	const char backslash = '\\';
 	if (str[*index] != double_quote || str.size() < 3) {
 		throw std::invalid_argument("[FormFile] Invalid value");
 	}
@@ -212,12 +211,7 @@ FormFile::ParseDoubleQuotedString(const std::string &str,
 	*index += 1;
 	bool found = false;
 	while (!found) {
-		if (str[*index] == backslash) {
-			if (*index + 2 >= str.size()) {
-				throw std::invalid_argument("[FormFile] Missing closing quote");
-			}
-			*index += 2;
-		} else if (str[*index] == double_quote) {
+		if (str[*index] == double_quote) {
 			found = true;
 		} else if (*index < str.size()) {
 			++(*index);

--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -41,7 +41,7 @@ void	FormFile::ParseRequestContentType_(const HttpRequest &request) {
 	const std::string directive =
 							TrimString(content_type.substr(start), kWhitespace);
 	const std::string name = "boundary=";
-	if (!directive.rfind(name, 0) == 0) {
+	if (directive.rfind(name, 0) != 0) {
 		throw std::invalid_argument("[FormFile] Invalid boundary");
 	}
 	boundary_ = directive.substr(name.length());

--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -29,22 +29,13 @@ void	FormFile::ParseRequestContentType_(const HttpRequest &request) {
 }
 
 /*
-** https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1
-POST /foo HTTP/1.1
-Content-Length: 68137
-Content-Type: multipart/form-data; boundary=something
-
---something
-Content-Disposition: form-data; name="myFile"; filename="foo.txt"
-Content-Type: text/plain
-
-(content of the uploaded file foo.txt)
---something--
-*/
-
-/*
 ** Example body
---something\r\nContent-Disposition: form-data; name="filename"; filename="foo.txt"\r\nContent-Type: text/plain\r\n\r\nfoobar\n\r\n--something--\r\n
+--something\r\n
+Content-Disposition: form-data; name="filename"; filename="foo.txt"\r\n
+Content-Type: text/plain\r\n
+\r\n
+foobar\n\r\n
+--something--\r\n
 */
 void	FormFile::ParseRequestBody_(const HttpRequest &request) {
 	const std::string dash_boundary = "--";
@@ -78,7 +69,9 @@ void	FormFile::ParseRequestBody_(const HttpRequest &request) {
 
 /*
 ** Example of the form headers
-Content-Disposition: form-data; name="myFile"; filename="foo.txt"\r\nContent-Type: text/plain\r\n\r\n
+Content-Disposition: form-data; name="myFile"; filename="foo.txt"\r\n
+Content-Type: text/plain\r\n
+\r\n
 */
 void	FormFile::ParseFormHeaders_(const std::string &headers) {
 	// Parse the content disposition

--- a/srcs/app/http/FormFile.cpp
+++ b/srcs/app/http/FormFile.cpp
@@ -131,7 +131,7 @@ void	FormFile::ParseFormHeaders_(const std::string &headers) {
 // Syntax: Content-Disposition: form-data; name="myFile"; filename="foo.txt"
 void	FormFile::ParseFormContentDisposition_(const std::string &header) {
 	// Parse header name
-	std::size_t start = ParseHeaderName(header, 0, "content-disposition");
+	std::size_t start = ParseHeaderName_(header, 0, "content-disposition");
 
 	// Parse the disposition type
 	std::size_t end = header.find(';', start);
@@ -153,7 +153,7 @@ void	FormFile::ParseFormContentDisposition_(const std::string &header) {
 				"[FormFile] Invalid Content-Disposition name");
 	}
 	index += name.size();
-	ParseDoubleQuotedString(header, &index);
+	ParseDoubleQuotedString_(header, &index);
 	index = header.find_first_not_of(kWhitespace, index);
 	if (index >= header.size() || header[index] != ';') {
 		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
@@ -168,7 +168,7 @@ void	FormFile::ParseFormContentDisposition_(const std::string &header) {
 				"[FormFile] Invalid Content-Disposition filename");
 	}
 	index += name.size();
-	const std::string quoted_filename = ParseDoubleQuotedString(header, &index);
+	const std::string quoted_filename = ParseDoubleQuotedString_(header, &index);
 	filename_ = TrimString(quoted_filename, "\"");
 	if (index != header.size()) {
 		throw std::invalid_argument("[FormFile] Invalid Content-Disposition");
@@ -177,11 +177,11 @@ void	FormFile::ParseFormContentDisposition_(const std::string &header) {
 
 // Syntax: Content-Type: image/gif
 void	FormFile::ParseFormContentType_(const std::string &header) const {
-	ParseHeaderName(header, 0, "content-type");
+	ParseHeaderName_(header, 0, "content-type");
 }
 
 std::string
-FormFile::ParseDoubleQuotedString(const std::string &str,
+FormFile::ParseDoubleQuotedString_(const std::string &str,
 									std::size_t *index) const {
 	const char double_quote = '"';
 	if (str[*index] != double_quote || str.size() < 3) {
@@ -205,7 +205,7 @@ FormFile::ParseDoubleQuotedString(const std::string &str,
 }
 
 std::size_t
-FormFile::ParseHeaderName(const std::string &str, std::size_t start,
+FormFile::ParseHeaderName_(const std::string &str, std::size_t start,
 							const std::string &name) const {
 	// Parse header name
 	std::size_t end = str.find(':', start);

--- a/srcs/app/test/http/FormFileTest.cpp
+++ b/srcs/app/test/http/FormFileTest.cpp
@@ -22,7 +22,7 @@ TEST_CASE("ValidFormFile", "[http]") {
 	REQUIRE("foobar\n" == form_file.GetFileContent());
 }
 
-TEST_CASE("ValidFormFileFieldsWithSpace", "[http]") {
+TEST_CASE("ValidFormFileFieldsWithSpaces", "[http]") {
 	const std::string raw_request =
 		"POST /foo HTTP/1.1\r\n"
 		"Host: 127.0.0.1:8000\r\n"
@@ -32,6 +32,26 @@ TEST_CASE("ValidFormFileFieldsWithSpace", "[http]") {
 		"--something\r\n"
 		"Content-Disposition: \tform-data ;name=\"foo\" ;filename=\"bar.txt\"\t\r\n"
 		"Content-Type: text/plain \r\n"
+		"\r\n"
+		"foobar\n\r\n"
+		"--something--\r\n";
+
+	HttpRequest request(raw_request);
+	FormFile form_file(request);
+	REQUIRE("bar.txt" == form_file.GetFilename());
+	REQUIRE("foobar\n" == form_file.GetFileContent());
+}
+
+TEST_CASE("ValidFormFileFieldsNoSpaces", "[http]") {
+	const std::string raw_request =
+		"POST /foo HTTP/1.1\r\n"
+		"Host: 127.0.0.1:8000\r\n"
+		"Content-Length: 125\r\n"
+		"Content-Type:multipart/form-data;boundary=something\r\n"
+		"\r\n"
+		"--something\r\n"
+		"Content-Disposition:form-data;name=\"foo\";filename=\"bar.txt\"\r\n"
+		"Content-Type:text/plain\r\n"
 		"\r\n"
 		"foobar\n\r\n"
 		"--something--\r\n";

--- a/srcs/app/test/http/FormFileTest.cpp
+++ b/srcs/app/test/http/FormFileTest.cpp
@@ -1,0 +1,23 @@
+#include <FormFile.hpp>
+#include <HttpRequest.hpp>
+#include <catch2.hpp>
+
+TEST_CASE("ValidFormFile", "[http]") {
+	const std::string raw_request =
+		"POST /foo HTTP/1.1\r\n"
+		"Host: 127.0.0.1:8000\r\n"
+		"Content-Length: 134\r\n"
+		"Content-Type: multipart/form-data; boundary=something\r\n"
+		"\r\n"
+		"--something\r\n"
+		"Content-Disposition: form-data; name=\"filename\"; filename=\"foo.txt\"\r\n"
+		"Content-Type: text/plain\r\n"
+		"\r\n"
+		"foobar\n\r\n"
+		"--something--\r\n";
+
+	HttpRequest request(raw_request);
+	FormFile form_file(request);
+	REQUIRE("foo.txt" == form_file.GetFilename());
+	REQUIRE("foobar\n" == form_file.GetFileContent());
+}

--- a/srcs/app/test/http/FormFileTest.cpp
+++ b/srcs/app/test/http/FormFileTest.cpp
@@ -21,3 +21,23 @@ TEST_CASE("ValidFormFile", "[http]") {
 	REQUIRE("foo.txt" == form_file.GetFilename());
 	REQUIRE("foobar\n" == form_file.GetFileContent());
 }
+
+TEST_CASE("ValidFormFileFieldsWithSpace", "[http]") {
+	const std::string raw_request =
+		"POST /foo HTTP/1.1\r\n"
+		"Host: 127.0.0.1:8000\r\n"
+		"Content-Length: 132\r\n"
+		"Content-Type: \t multipart/form-data  ; boundary=something \t \r\n"
+		"\r\n"
+		"--something\r\n"
+		"Content-Disposition: \tform-data ;name=\"foo\" ;filename=\"bar.txt\"\t\r\n"
+		"Content-Type: text/plain \r\n"
+		"\r\n"
+		"foobar\n\r\n"
+		"--something--\r\n";
+
+	HttpRequest request(raw_request);
+	FormFile form_file(request);
+	REQUIRE("bar.txt" == form_file.GetFilename());
+	REQUIRE("foobar\n" == form_file.GetFileContent());
+}

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -22,9 +22,10 @@ class FormFile {
 		void		ParseFormHeaders_(const std::string &headers);
 		void		ParseFormContentDisposition_(const std::string &header);
 		void		ParseFormContentType_(const std::string &header) const;
-		std::size_t	SkipSpace(const std::string &str, std::size_t index) const;
 		std::string	ParseDoubleQuotedString(
 							const std::string &str, std::size_t *index) const;
+		std::size_t	ParseHeaderName(const std::string &str, std::size_t index,
+									const std::string &name) const;
 };
 
 #endif  // SRCS_INCS_FORMFILE_HPP_

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -28,8 +28,8 @@ class FormFile {
 		std::size_t	ParseMediaType_(const std::string &str, std::size_t index,
 									const std::string &name) const;
 		void		ParseBoundary_(const std::string &str, std::size_t index);
-		std::size_t	ParsePairName_(const std::string &str, std::size_t index,
-									const std::string &name) const;
+		std::size_t	SkipWord_(const std::string &str, std::size_t index,
+									const std::string &word) const;
 		std::size_t	SkipWhitespace_(const std::string &str,
 									std::size_t index) const;
 };

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -28,6 +28,8 @@ class FormFile {
 		std::size_t	ParseMediaType_(const std::string &str, std::size_t index,
 									const std::string &name) const;
 		void		ParseBoundary_(const std::string &str, std::size_t index);
+		std::size_t	ParsePairName_(const std::string &str, std::size_t index,
+									const std::string &name) const;
 };
 
 #endif  // SRCS_INCS_FORMFILE_HPP_

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -22,9 +22,9 @@ class FormFile {
 		void		ParseFormHeaders_(const std::string &headers);
 		void		ParseFormContentDisposition_(const std::string &header);
 		void		ParseFormContentType_(const std::string &header) const;
-		std::string	ParseDoubleQuotedString(
+		std::string	ParseDoubleQuotedString_(
 							const std::string &str, std::size_t *index) const;
-		std::size_t	ParseHeaderName(const std::string &str, std::size_t index,
+		std::size_t	ParseHeaderName_(const std::string &str, std::size_t index,
 									const std::string &name) const;
 };
 

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -30,6 +30,8 @@ class FormFile {
 		void		ParseBoundary_(const std::string &str, std::size_t index);
 		std::size_t	ParsePairName_(const std::string &str, std::size_t index,
 									const std::string &name) const;
+		std::size_t	SkipWhitespace_(const std::string &str,
+									std::size_t index) const;
 };
 
 #endif  // SRCS_INCS_FORMFILE_HPP_

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -1,0 +1,30 @@
+#ifndef SRCS_INCS_FORMFILE_HPP_
+#define SRCS_INCS_FORMFILE_HPP_
+#include <string>
+#include <HttpRequest.hpp>
+
+class FormFile {
+	public:
+		explicit FormFile(const HttpRequest &request);
+		std::string	GetFilename() const;
+		std::string	GetFileContent() const;
+
+	private:
+		std::string	filename_;
+		std::string	file_content_;
+		std::string	boundary_;
+
+		static const char kCRLF[];
+		static const char kWhitespace[];
+
+		void		ParseRequestContentType_(const HttpRequest &request);
+		void		ParseRequestBody_(const HttpRequest &request);
+		void		ParseFormHeaders_(const std::string &headers);
+		void		ParseFormContentDisposition_(const std::string &header);
+		void		ParseFormContentType_(const std::string &header) const;
+		std::size_t	SkipSpace(const std::string &str, std::size_t index) const;
+		std::string	ParseDoubleQuotedString(
+							const std::string &str, std::size_t *index) const;
+};
+
+#endif  // SRCS_INCS_FORMFILE_HPP_

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -27,6 +27,7 @@ class FormFile {
 									const std::string &name) const;
 		std::size_t	ParseMediaType_(const std::string &str, std::size_t index,
 									const std::string &name) const;
+		void		ParseBoundary_(const std::string &str, std::size_t index);
 };
 
 #endif  // SRCS_INCS_FORMFILE_HPP_

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -25,6 +25,8 @@ class FormFile {
 							const std::string &str, std::size_t *index) const;
 		std::size_t	ParseHeaderName_(const std::string &str, std::size_t index,
 									const std::string &name) const;
+		std::size_t	ParseMediaType_(const std::string &str, std::size_t index,
+									const std::string &name) const;
 };
 
 #endif  // SRCS_INCS_FORMFILE_HPP_

--- a/srcs/incs/FormFile.hpp
+++ b/srcs/incs/FormFile.hpp
@@ -21,7 +21,6 @@ class FormFile {
 		void		ParseRequestBody_(const HttpRequest &request);
 		void		ParseFormHeaders_(const std::string &headers);
 		void		ParseFormContentDisposition_(const std::string &header);
-		void		ParseFormContentType_(const std::string &header) const;
 		std::string	ParseDoubleQuotedString_(
 							const std::string &str, std::size_t *index) const;
 		std::size_t	ParseHeaderName_(const std::string &str, std::size_t index,


### PR DESCRIPTION
This class encapsulates and parses the body of a POST message containing a file uploaded with an HTML form.

Example of the HTTP request:
```
POST /upload/ HTTP/1.1
(other HTTP headers)
Content-Type: multipart/form-data; boundary=something

--something
Content-Disposition: form-data; name="upload"; filename="file.txt"
Content-Type: text/plain

(The contents of the file)
--something--
```