### PR TITLE
2/8 - #94 subtask/shared set container

### DIFF
--- a/srcs/app/server/FDsets.cpp
+++ b/srcs/app/server/FDsets.cpp
@@ -1,0 +1,41 @@
+#include <FDsets.hpp>
+#include <cstring>
+
+FDsets::FDsets() {
+	FD_ZERO(&read_set_);
+	FD_ZERO(&write_set_);
+}
+
+void	FDsets::removeFromReadSet(int fd) {
+	FD_CLR(fd, &read_set_);
+}
+
+void	FDsets::removeFromWriteSet(int fd) {
+	FD_CLR(fd, &write_set_);
+}
+
+void	FDsets::addToWriteSet(int fd) {
+	FD_SET(fd, &write_set_);
+}
+
+void	FDsets::addToReadSet(int fd) {
+	FD_SET(fd, &read_set_);
+}
+
+fd_set	*FDsets::getReadSet() {
+	std::memcpy(&tmp_read_set_, &read_set_, sizeof(read_set_));
+	return &tmp_read_set_;
+}
+
+fd_set	*FDsets::getWriteSet() {
+	std::memcpy(&tmp_write_set_, &write_set_, sizeof(read_set_));
+	return &tmp_write_set_;
+}
+
+bool		FDsets::isReadSet(int fd) const {
+	return FD_ISSET(fd, &tmp_read_set_);
+}
+
+bool		FDsets::isWriteSet(int fd) const {
+	return FD_ISSET(fd, &tmp_write_set_);
+}

--- a/srcs/incs/FDsets.hpp
+++ b/srcs/incs/FDsets.hpp
@@ -1,0 +1,25 @@
+#ifndef SRCS_INCS_FDSETS_HPP_
+#define SRCS_INCS_FDSETS_HPP_
+
+#include <sys/socket.h>
+
+class FDsets {
+	public:
+		FDsets();
+		void		removeFromReadSet(int fd);
+		void		removeFromWriteSet(int fd);
+		void		addToWriteSet(int fd);
+		void		addToReadSet(int fd);
+		fd_set		*getReadSet();
+		fd_set		*getWriteSet();
+		bool		isReadSet(int fd) const;
+		bool		isWriteSet(int fd) const;
+
+	private:
+		fd_set		read_set_;
+		fd_set		tmp_read_set_;
+		fd_set		write_set_;
+		fd_set		tmp_write_set_;
+};
+
+#endif  // SRCS_INCS_FDSETS_HPP_

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -18,6 +18,7 @@
 #include <parser/Analyser.hpp>
 #include <Server.hpp>
 #include <ServerConfig.hpp>
+#include <FDsets.hpp>
 
 class WebServer {
 	private:
@@ -26,10 +27,7 @@ class WebServer {
 
 		Config		config_;
 		ServersMap_	servers_;
-		fd_set		all_set_;
-		fd_set		write_set_;
-		fd_set		tmp_read_set_;
-		fd_set		tmp_write_set_;
+		FDsets		fdSets;
 		int			max_sd_;
 
 	public:


### PR DESCRIPTION
## Note
If you haven't yet, please read #76 before continuing

## What has been done?

This PR solves #94. The idea behind it is to create an encapsulated socket's `fd_sets` in a single object. This way we will be able to inject it in desired layers to update `fds` on desired ones, making easier to delegate responsibilities and implementing CGI. This PR only implement this object in `WebServer` class.