### PR TITLE
Move cgi handling to server

### DIFF
--- a/srcs/app/server/Server.cpp
+++ b/srcs/app/server/Server.cpp
@@ -11,6 +11,10 @@ Server::~Server() {
 		close(it->first);
 		delete it->second;
 	}
+	CgiHandlersMap_::iterator h_it = cgi_handlers_.begin();
+	for (; h_it != cgi_handlers_.end(); ++h_it) {
+		delete h_it->second;
+	}
 	close(listen_sd_);
 }
 
@@ -91,7 +95,7 @@ void Server::HandleCgiSend(int sd) {
 	}
 }
 
-void	Server::BindListeningSocket_() {
+void	Server::BindListeningSocket_() const {
 	if (fcntl(listen_sd_, F_SETFL, O_NONBLOCK) < 0) {
 		throw std::runtime_error(std::strerror(errno));
 	}

--- a/srcs/app/server/WebServer.cpp
+++ b/srcs/app/server/WebServer.cpp
@@ -10,10 +10,6 @@ WebServer::~WebServer() {
 	for (; it != servers_.end(); ++it) {
 		delete it->second;
 	}
-	CgiHandlersMap_::iterator h_it = cgi_handlers_.begin();
-	for (; h_it != cgi_handlers_.end(); ++h_it) {
-		delete h_it->second;
-	}
 }
 
 void	WebServer::Run() {

--- a/srcs/incs/Server.hpp
+++ b/srcs/incs/Server.hpp
@@ -31,7 +31,7 @@ class Server {
 		Server(const Server &);
 		Server &	operator=(const Server &);
 		void	AddConnection_(int sd);
-		void	BindListeningSocket_();
+		void	BindListeningSocket_() const;
 		void	AddCgiHandler_(int sd, int cgi_output_fd);
 		void	RemoveCgiHandler_(CgiHandler *handler, int sd, int fd);
 		void	RemoveConnection_(int sd);

--- a/srcs/incs/Server.hpp
+++ b/srcs/incs/Server.hpp
@@ -12,17 +12,19 @@
 #include <HttpResponseFactory.hpp>
 #include <ServerConfig.hpp>
 #include <FDsets.hpp>
+#include <CgiHandler.hpp>
 
 class Server {
 	public:
 		Server(const ServerConfig &settings, int listen_sd, FDsets *fdSets);
 		~Server();
 		void	AcceptNewConnection();
-		void	RemoveConnection(int sd);
 		bool	HasConnection(int sd);
+		bool	HasCgiHandler(int sd);
 		void	ReceiveRequest(int sd);
-		SendResponseStatus::Type	SendResponse(int sd);
-		int		GetCgiOutputFd(int sd);
+		void	HandleCgiRead(int fd);
+		void	SendResponse(int sd);
+		void 	HandleCgiSend(int sd);
 
 	private:
 		Server();
@@ -30,10 +32,20 @@ class Server {
 		Server &	operator=(const Server &);
 		void	AddConnection_(int sd);
 		void	BindListeningSocket_();
+		void	AddCgiHandler_(int sd, int cgi_output_fd);
+		void	RemoveCgiHandler_(CgiHandler *handler, int sd, int fd);
+		void	RemoveConnection_(int sd);
 
-		ServerConfig			settings_;
-		int						listen_sd_;
-		FDsets					*fdSets_;
+		typedef	int					Socket_;
+		typedef	int					Fd_;
+		typedef std::map<Fd_, CgiHandler *>	CgiHandlersMap_;
+		typedef std::map<Socket_, Fd_>		CgiSocketFdsMap_;
+
+		ServerConfig				settings_;
+		int							listen_sd_;
+		FDsets						*fdSets_;
+		CgiHandlersMap_				cgi_handlers_;
+		CgiSocketFdsMap_			cgi_fds_;
 		std::map<int, Connection *>	connections_;
 };
 

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -13,7 +13,6 @@
 #include <stdexcept>
 #include <string>
 #include <map>
-#include <CgiHandler.hpp>
 #include <Config.hpp>
 #include <ConnectionIOStatus.hpp>
 #include <FDsets.hpp>
@@ -44,13 +43,6 @@ class WebServer {
 		Config		config_;
 		ServersMap_	servers_;
 		FDsets		fdSets;
-
-		typedef int							Fd_;
-		typedef std::map<Fd_, CgiHandler *>	CgiHandlersMap_;
-		typedef std::map<Socket_, Fd_>		CgiSocketFdsMap_;
-
-		CgiHandlersMap_ 	cgi_handlers_;
-		CgiSocketFdsMap_	cgi_fds_;
 };
 
 #endif  // SRCS_INCS_WEBSERVER_HPP_

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -34,16 +34,10 @@ class WebServer {
 		WebServer &	operator=(const WebServer &);
 		void	PopulateServers_();
 		Server	*FindServer_(int sd);
-		Server	*FindServerConnection_(int sd);
+		Server	*FindServerWithConnection_(int sd);
+		Server	*FindServerWithCgiHandler_(int sd);
 		void	HandleReadSocket_(int sd);
 		void	HandleWriteSocket_(int sd);
-
-		bool	IsCgiFd_(int fd) const;
-		bool	IsCgiSocket_(int sd) const;
-		void	RemoveCgiHandler_(CgiHandler *handler, int sd, int fd);
-		void	HandleCgiRead_(int fd);
-		void	HandleCgiSend_(int sd);
-		void	AddCgiHandler_(Server *server, int sd);
 
 		typedef	int							Socket_;
 		typedef std::map<Socket_, Server *>	ServersMap_;


### PR DESCRIPTION
Co-Authored-By: gbudau <54190400+gbudau@users.noreply.github.com>

 We've decided to move `CGI` handling to `Server` class since it made more sense to have it here next to connections. Once a connection is ended (due to a CGI coming) we start communicating through it and, hence, makes sense to have in this scope because it's replacing a connection.