### PR TITLE
Add integration tests for non-blocking cgi

### DIFF
--- a/.github/workflows/integration_test_check.yml
+++ b/.github/workflows/integration_test_check.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Check out Github repository
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.7"
 
       - name: Install dependencies
         working-directory: ./srcs/app/test/integration

--- a/html/web3/cgi-bin/slow_cgi.py
+++ b/html/web3/cgi-bin/slow_cgi.py
@@ -7,6 +7,6 @@ print('Content-type: text/html\r\n\r\n')
 print('<font size=+1>Environment</font><br>')
 for param in os.environ.keys():
     print('<b>%20s</b>: %s<br>' % (param, os.environ[param]))
-for i in range(0, 2, 1):
+for i in range(2):
     print(i)
-    time.sleep(10)
+    time.sleep(1)

--- a/html/web3/cgi-bin/slow_cgi.py
+++ b/html/web3/cgi-bin/slow_cgi.py
@@ -2,11 +2,23 @@
 
 import time
 import os
+import cgi
+
+form = cgi.FieldStorage()
+seconds = form.getvalue('seconds')
 
 print('Content-type: text/html\r\n\r\n')
 print('<font size=+1>Environment</font><br>')
 for param in os.environ.keys():
     print('<b>%20s</b>: %s<br>' % (param, os.environ[param]))
-for i in range(2):
+
+try:
+    number = int(seconds)
+    if number < 1:
+        number = 1
+except ValueError:
+    number = 1
+
+for i in range(number):
     print(i)
     time.sleep(1)

--- a/html/web3/slow_cgi.html
+++ b/html/web3/slow_cgi.html
@@ -5,6 +5,9 @@
 <h1>Slowly print some CGI output indexes</h1>
 
 <form action="cgi-bin/slow_cgi.py" method="post">
+  <label for="seconds">Number of seconds to sleep:</label>
+  <input type="number" required="required" step="1" min="1"
+	       id="seconds" name="seconds"><br><br>
   <input type="submit" value="Print">
 </form>
 

--- a/srcs/app/test/integration/requirements.txt
+++ b/srcs/app/test/integration/requirements.txt
@@ -1,2 +1,3 @@
-pytest==5.4.3
-requests>=2.20.0
+aiohttp==3.8.1
+pytest==6.2.5
+requests==2.26.0

--- a/srcs/app/test/integration/webserv_test.py
+++ b/srcs/app/test/integration/webserv_test.py
@@ -177,11 +177,11 @@ async def async_get_request(session, url):
     async with session.get(url) as resp:
         return resp.status
 
-async def async_get_php_info_cgi(number):
+async def async_get_php_info_cgi(requests_number, seconds):
     async with aiohttp.ClientSession() as session:
         tasks = []
-        url = 'http://localhost:8084/cgi-bin/slow_cgi.py'
-        for _ in range(number):
+        url = 'http://localhost:8084/cgi-bin/slow_cgi.py?seconds=' + str(seconds)
+        for _ in range(requests_number):
             tasks.append(asyncio.ensure_future(async_get_request(session, url)))
 
         statuses = await asyncio.gather(*tasks)
@@ -189,4 +189,9 @@ async def async_get_php_info_cgi(number):
             assert status == 200
 
 def test_get_env_slow_cgi():
-    asyncio.run(async_get_php_info_cgi(20))
+    requests_number = 20
+    seconds = 2
+    start_time = time.time()
+    asyncio.run(async_get_php_info_cgi(requests_number, seconds))
+    end_time = time.time()
+    assert end_time - start_time < requests_number * seconds

--- a/srcs/app/test/integration/webserv_test.py
+++ b/srcs/app/test/integration/webserv_test.py
@@ -177,7 +177,7 @@ async def async_get_request(session, url):
     async with session.get(url) as resp:
         return resp.status
 
-async def async_get_php_info_cgi(requests_number, seconds):
+async def async_get_slow_cgi(requests_number, seconds):
     async with aiohttp.ClientSession() as session:
         tasks = []
         url = 'http://localhost:8084/cgi-bin/slow_cgi.py?seconds=' + str(seconds)
@@ -192,6 +192,6 @@ def test_get_env_slow_cgi():
     requests_number = 20
     seconds = 2
     start_time = time.time()
-    asyncio.run(async_get_php_info_cgi(requests_number, seconds))
+    asyncio.run(async_get_slow_cgi(requests_number, seconds))
     end_time = time.time()
     assert end_time - start_time < requests_number * seconds


### PR DESCRIPTION
This PR adds integration tests for the non-blocking cgi.

We test this by making asynchronous(concurrent) requests.

Inspired by [this blog post](https://www.twilio.com/blog/asynchronous-http-requests-in-python-with-aiohttp).