### PR TITLE
fix persistent memleak when throwing from PopulateConfigMaps

### DIFF
--- a/srcs/CGI/CGI.cpp
+++ b/srcs/CGI/CGI.cpp
@@ -136,9 +136,10 @@ std::string	CGI::MakeClientAddress_() {
 
 	len = sizeof(addr);
 	SyscallWrap::getpeernameWr(request_.GetSocket(),
-												(struct sockaddr *)&addr, &len);
+							(struct sockaddr *)&addr, &len DEBUG_INFO);
 	struct sockaddr_in *src = (struct sockaddr_in *)&addr;
-	SyscallWrap::inet_ntopWr(AF_INET, &src->sin_addr, ipstr, sizeof(ipstr));
+	SyscallWrap::inet_ntopWr(AF_INET, &src->sin_addr, ipstr, sizeof(ipstr)
+	DEBUG_INFO);
 	return ipstr;
 }
 

--- a/srcs/incs/WebServer.hpp
+++ b/srcs/incs/WebServer.hpp
@@ -41,6 +41,8 @@ class WebServer {
 		void	HandleReadSocket_(int sd);
 		void	HandleWriteSocket_(int sd);
 		typedef std::map<const std::string, ServerConfig *> serverSettingsMap;
+		void	DeallocationHelper_(
+			WebServer::serverSettingsMap *serverSettingsMap, Server *server);
 		serverSettingsMap
 					*BuildServerSettings_(std::vector<ServerConfig> *config);
 		void	DeleteDuplicatedServerNames_(

--- a/srcs/server/WebServer.cpp
+++ b/srcs/server/WebServer.cpp
@@ -6,10 +6,7 @@ WebServer::WebServer(const std::string &pathname) {
 }
 
 WebServer::~WebServer() {
-	ServersMap_::iterator it = servers_.begin();
-	for (; it != servers_.end(); ++it) {
-		delete it->second;
-	}
+	DeallocationHelper_(NULL, NULL);
 }
 
 void	WebServer::Run() {
@@ -46,20 +43,7 @@ void	WebServer::PopulateServers_() {
 			serverSettingsMap = BuildServerSettings_(&config);
 			server = new Server(serverSettingsMap, listen_sd, &fdSets);
 		} catch (const std::exception &e) {
-			delete server;
-			if (serverSettingsMap) {
-				for (WebServer::serverSettingsMap::iterator it =
-					serverSettingsMap->begin();
-				it != serverSettingsMap->end();
-				++it) {
-					delete it->second;
-				}
-			}
-			delete serverSettingsMap;
-			ServersMap_::iterator it = servers_.begin();
-			for (; it != servers_.end(); ++it) {
-				delete it->second;
-			}
+			DeallocationHelper_(serverSettingsMap, server);
 			throw std::runtime_error(e.what());
 		}
 		servers_.insert(std::make_pair(listen_sd, server));
@@ -177,5 +161,23 @@ void	WebServer::HandleWriteSocket_(int sd) {
 		server->SendResponse(sd);
 	} else if ((server = FindServerWithCgiHandler_(sd))) {
 		server->HandleCgiSend(sd);
+	}
+}
+
+void WebServer::DeallocationHelper_(
+	WebServer::serverSettingsMap *serverSettingsMap, Server *server) {
+	delete server;
+	if (serverSettingsMap) {
+		for (WebServer::serverSettingsMap::iterator it =
+			serverSettingsMap->begin();
+			 it != serverSettingsMap->end();
+			 ++it) {
+			delete it->second;
+		}
+	}
+	delete serverSettingsMap;
+	ServersMap_::iterator it = servers_.begin();
+	for (; it != servers_.end(); ++it) {
+		delete it->second;
 	}
 }

--- a/srcs/server/WebServer.cpp
+++ b/srcs/server/WebServer.cpp
@@ -41,12 +41,22 @@ void	WebServer::PopulateServers_() {
 
 		fdSets.addToReadSet(listen_sd);
 		Server *server = NULL;
+		WebServer::serverSettingsMap *serverSettingsMap = NULL;
 		try {
-			server =
-				new Server(BuildServerSettings_(&config), listen_sd, &fdSets);
+			serverSettingsMap = BuildServerSettings_(&config);
+			server = new Server(serverSettingsMap, listen_sd, &fdSets);
 		} catch (const std::exception &e) {
 			delete server;
-			throw e;
+			if (serverSettingsMap) {
+				for (WebServer::serverSettingsMap::iterator it =
+					serverSettingsMap->begin();
+				it != serverSettingsMap->end();
+				++it) {
+					delete it->second;
+				}
+			}
+			delete serverSettingsMap;
+			throw std::runtime_error(e.what());
 		}
 		servers_.insert(std::make_pair(listen_sd, server));
 	}

--- a/srcs/server/WebServer.cpp
+++ b/srcs/server/WebServer.cpp
@@ -56,6 +56,10 @@ void	WebServer::PopulateServers_() {
 				}
 			}
 			delete serverSettingsMap;
+			ServersMap_::iterator it = servers_.begin();
+			for (; it != servers_.end(); ++it) {
+				delete it->second;
+			}
 			throw std::runtime_error(e.what());
 		}
 		servers_.insert(std::make_pair(listen_sd, server));

--- a/srcs/utils/SyscallWrap.cpp
+++ b/srcs/utils/SyscallWrap.cpp
@@ -161,7 +161,7 @@ const char *	SyscallWrap::inet_ntopWr(int af,
 										 const void *src,
 										 char *dst,
 										 socklen_t size DEBUG_ARGS) {
-	const char *ret = inet_ntop(af, src, dst, size DEBUG_ARGS_NAMES);
+	const char *ret = inet_ntop(af, src, dst, size);
 	if (ret == NULL) {
 		ThrowException_("inet_ntop" DEBUG_ARGS_NAMES);
 	}


### PR DESCRIPTION
I had to rush and I couldn't properly test this. I have managed to fix the leak, that would otherwise be reproducible when trying with such a config file, in case we had another server running on port 80:
```
server {
listen 80;
}
```
or, even worse, for example this:
```
server {
	listen			8080;
	server_name		localhost;
	autoindex		on;
	index			nonexistent.html;
}

server {
	listen			8081;
	server_name		localhost;
	root			html/web1;

	location		/google {
		return 301	https://www.google.com;
	}
}

server {
	listen			80;
	return 301		https://www.google.com;
}
```
(several valid servers, and one server that would break upon binding to its port)
Also, the debugging build was broken due to some improperly used macros in when calling some of the newly added syscalls.