### PR TITLE
Task/add additional http env

### DIFF
--- a/srcs/incs/CGI.hpp
+++ b/srcs/incs/CGI.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <HttpHeaders.hpp>
 #include <HttpRequest.hpp>
 #include <RequestConfig.hpp>
 #include <SyscallWrap.hpp>
@@ -35,8 +36,10 @@ class CGI {
 	CGI(const CGI &);
 	CGI & operator=(const CGI &);
 
+	typedef std::map<std::string, std::string> EnvsMap_;
 	std::string GetExecutable_();
 	std::map<std::string, std::string> MakeEnv_(void);
+	void AddHttpEnv_(EnvsMap_ *envs);
 	char **MakeCEnv_(void);
 	void CloseAssign_(int *fd);
 	std::string MakeClientAddress_();
@@ -47,7 +50,7 @@ class CGI {
 	std::string client_address_;
 	const std::string arg_path_;
 	const std::string exec_path_;
-	const std::map<std::string, std::string> CGIenvMap_;
+	const EnvsMap_ CGIenvMap_;
 	char * const *CGIenv_;
 	int fds_[2];
 };

--- a/srcs/incs/Utils.hpp
+++ b/srcs/incs/Utils.hpp
@@ -12,6 +12,7 @@
 
 std::string	TrimString(const std::string &str, const std::string &trim_chars);
 std::string	ToLowerString(std::string str);
+std::string	ToUpperString(std::string str);
 char		*DuplicateString(const std::string &str);
 std::string	DecodeUrl(const std::string &encoded_url);
 std::string	PathExtension(const std::string &path);

--- a/srcs/utils/Utils.cpp
+++ b/srcs/utils/Utils.cpp
@@ -14,6 +14,11 @@ std::string	ToLowerString(std::string str) {
 	return str;
 }
 
+std::string	ToUpperString(std::string str) {
+	std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+	return str;
+}
+
 char *DuplicateString(const std::string &str) {
 	char *element = new char[str.size() + 1];
 	std::memcpy(element, str.c_str(), str.size() + 1);


### PR DESCRIPTION
This change fixes the `401 Unauthorized` error we got while testing WordPress.

[RFC 3875](https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.18)
```
   Meta-variables with names beginning with "HTTP_" contain values read
   from the client request header fields, if the protocol used is HTTP.
   The HTTP header field name is converted to upper case, has all
   occurrences of "-" replaced with "_" and has "HTTP_" prepended to
   give the meta-variable name.  The header data can be presented as
   sent by the client, or can be rewritten in ways which do not change
   its semantics.  If multiple header fields with the same field-name
   are received then the server MUST rewrite them as a single value
   having the same semantics.  Similarly, a header field that spans
   multiple lines MUST be merged onto a single line.  The server MUST,
   if necessary, change the representation of the data (for example, the
   character set) to be appropriate for a CGI meta-variable.
```